### PR TITLE
Fixed maskRcnn link and coco setup problem

### DIFF
--- a/segmentation/install_package.bash
+++ b/segmentation/install_package.bash
@@ -4,7 +4,7 @@ CURDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/devine_segmentation"
 echo "export ROS_PACKAGE_PATH=$CURDIR:\$ROS_PACKAGE_PATH" >> ~/.bashrc
 
 #Env setup
-sudo pip install --upgrade setuptools
+sudo pip3 install --upgrade setuptools
 sudo pip3 install Cython scikit-image bson pymongo pycocotools keras catkin_pkg rospkg
 wget https://github.com/matterport/Mask_RCNN/releases/download/v2.0/mask_rcnn_coco.h5
 


### PR DESCRIPTION
Changed the link for the MaskRCNN and added a line which updates setup tools for python