### PR TITLE
Fixed and cleaned up tests.

### DIFF
--- a/tests/image_tests/image_segmentation.py
+++ b/tests/image_tests/image_segmentation.py
@@ -1,119 +1,104 @@
 #! /usr/bin/env python2
-''' Test to validate segmentation rates '''
-import argparse
-import rospy
-from devine_config import topicname
+""" Test to validate segmentation rates """
 from Queue import Queue, Empty
+import argparse
 import json
+import os
+import rospy
 import cv2
-from sensor_msgs.msg import CompressedImage
-from cv_bridge import CvBridge, CvBridgeError
 import numpy as np
+from collections import Counter
 from std_msgs.msg import String
+from sensor_msgs.msg import CompressedImage
+from devine_config import topicname
 
 IMAGE_TOPIC = topicname('segmentation_image')
 SEGMENTATION_IMAGE_TOPIC = topicname('objects')
 
-def list_diff(x1,x2):
-    """ Returns the difference between two lists"""
-    i = len(x1)-1
-    j = len(x2)-1
-    x1.sort()
-    x2.sort()
-    while i >= 0 and j >= 0:
-    	if x1[i] > x2[j]:
-    		i-=1
-    	elif x1[i] < x2[j]:
-    		j-=1
-    	else:
-    		del x1[i]
-    		del x2[j]
-    		i-=1
-    		j-=1
-    return [x1,x2]
-    
-def load_test_data(test_name):
-    """ Loads test data and images"""    
-    imgs = []
-    data = []
-    with open(test_name + '.json') as json_data:
-        test_data = json.load(json_data)
+IMAGE_PUB = rospy.Publisher(IMAGE_TOPIC, CompressedImage, queue_size=1)
 
-    for test in test_data["tests"]:
-        imgs.append(cv2.imread(test["imageName"],cv2.IMREAD_COLOR))
-        data.append(test["refData"]["objects"])
-    return imgs,data
+IMAGE_MSG = "image_msg"
+EXPECTED_OBJECTS = "expected_objects"
 
-def flatten_json(data):
-    """ Takes input json object and returns a list"""
-    return [object["category"] for object in data["objects"]]
 
-def segmentation_call_back(data):
-    '''Callback for segmentation topic'''
-    if seg_queue.full():
-        seg_queue.get()
-    try:
-        seg_queue.put(flatten_json(json.loads(data.data)))
-    except Exception as e:
-        rospy.logerr(e)
+def image_file_to_ros_msg(image_path):
+    """ Convert an image file to a ros readable data message """
+    img = cv2.imread(get_fullpath(image_path), cv2.IMREAD_COLOR)
 
-def run_test(image,ref_data):
-    """ Evaluates  segmentation rate for a single image """
-    #send over node
-    segmentation_pub = rospy.Publisher(IMAGE_TOPIC, CompressedImage, queue_size=1)
-    rospy.Subscriber(SEGMENTATION_IMAGE_TOPIC, String, segmentation_call_back)
-    #is_blurry = is_image_blurry(image.data)
-    image_message = CvBridge().cv2_to_imgmsg(image)    
-    ### Create CompressedIamge ####
     msg = CompressedImage()
     msg.header.stamp = rospy.Time.now()
     msg.format = "png"
-    msg.data = np.array(cv2.imencode('.png', image)[1]).tostring()
-    rospy.sleep(1)
-    segmentation_pub.publish(msg)
-    rospy.sleep(1)
-    #receive data
-    try:
-        results = seg_queue.get()
-        [missed_detections,false_detections] = list_diff(ref_data,results)
-        missed_detection_count = len(missed_detections)
-        false_detection_count = len(false_detections)
-    except Empty:
-        missed_detection_count = -1
-        false_detection_count = -1
-    #extract and comp dat
-    return [missed_detection_count,false_detection_count]
-    
+    msg.data = np.array(cv2.imencode('.png', img)[1]).tostring()
 
-def main(args):
-    '''Loads images and posts the corresponding segmentation rates'''
-    # Parse arguments
-    test_name = args.test
+    return msg
+
+
+def load_test_images(test_filepath):
+    """ Loads test data and images"""
+    test_images = []
+    with open(test_filepath) as json_data:
+        file_data = json.load(json_data)
+
+    for test in file_data["tests"]:
+        test_images.append({
+            IMAGE_MSG: image_file_to_ros_msg(test["imageName"]),
+            EXPECTED_OBJECTS: test["refData"]["objects"]
+        })
+
+    return test_images
+
+
+def get_segmented_objets(data):
+    """ Extract a list of the segmented objects found in the given ros data """
+    json_data = json.loads(data.data)
+    return [object["category"] for object in json_data["objects"]]
+
+
+def get_missed_objects(expected_objects, actual_objects):
+    """ Return the list of all objects that were not detected """
+    return list((Counter(expected_objects) - Counter(actual_objects)).elements())
+
+
+def test_segmentation_should_find_most_of_the_objects(test_image):
+    """ Evaluates  segmentation rate for a single image """
+    expected_objects = test_image[EXPECTED_OBJECTS]
+
+    # send over node
+    IMAGE_PUB.publish(test_image[IMAGE_MSG])
+    # receive data
+    data = rospy.wait_for_message(SEGMENTATION_IMAGE_TOPIC, String)
+    rospy.logwarn("Message timestamp: %s", json.loads(data.data)['timestamp'])
+    objects_found = get_segmented_objets(data)
+
+    missed_objects = get_missed_objects(expected_objects, objects_found)
+    other_found_objects = get_missed_objects(objects_found, expected_objects)
+
+    rospy.loginfo("Number of missed detections: %d", len(missed_objects))
+    rospy.loginfo("Number of other detected objects: %d", len(other_found_objects))
+    objects_missed_ratio = float(len(missed_objects)) / len(expected_objects)
+    rospy.loginfo("Percentage of objects missed: %.02f", objects_missed_ratio)
+    if objects_missed_ratio >= 0.5:
+        rospy.logwarn("The ratio of objects missed if greater than 50%.")
+
+
+def get_fullpath(relative_file):
+    """ Return the full path of a file in a directory relative to this one """
+    return os.path.join(os.path.dirname(os.path.abspath(__file__)), relative_file)
+
+
+def main():
+    """ Loads images and posts the corresponding segmentation rates """
     # Start ROS node
-    rospy.init_node('image_seg_test')
-    global seg_queue
-    seg_queue  = Queue(1)
-    [imgs,data] = load_test_data(test_name)
+    rospy.init_node("image_seg_test")
+    test_images = load_test_images(get_fullpath("test.json"))
+
     pos = 0
-    rate = rospy.Rate(1)
-    while not rospy.is_shutdown() and pos < len(imgs):
-        [missed_detection_count,false_detection_count] = run_test(imgs[pos],data[pos])
+    while not rospy.is_shutdown() and pos < len(test_images):
+        rospy.loginfo("### Test image %d ###", pos + 1)
+        test_segmentation_should_find_most_of_the_objects(test_images[pos])
+        rospy.sleep(0.5)
         pos += 1
-        rospy.loginfo("Num missed detections" + str(missed_detection_count))
-        rospy.loginfo("Num false detections: " + str(false_detection_count))
-        rate.sleep()
-        print("Percentage of objects missed: " + str(float(missed_detection_count)/len(data[pos-1])))
-        print("Number of objects falsely detected: ",false_detection_count)
 
-def parser():
-    ''' Command Line Parser'''
-    arg_fmt = argparse.RawDescriptionHelpFormatter
-    arg_parser = argparse.ArgumentParser(formatter_class=arg_fmt, description=main.__doc__)
-    image_options = arg_parser.add_argument_group('Image options')
-    image_options.add_argument('-t', '--test', required=True, help='What test to run')
-    arguments = arg_parser.parse_args(rospy.myargv()[1:])
-    return arguments
 
-if __name__ == '__main__':
-    main(parser())
-    rospy.spin()
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description

What this PR changes in the segmentation tests:

- Cleanup code (unused imports, unused variables, better separation in smaller functions, etc)
- Fix test not outputing the right percentage of missed objects in dectection
- Use an hardcoded value to read the test.json file, because this test is made only for that file and this will allow to run the test in any folder.
- Better display messages

What will be done in another PR(s):

- Tests with different images
- Fix for the bug that always uses the first segmented data for all image (see screenshot below, was already there before that PR, I will investigate it.)
- Little refact to run the tests in a more `pytest` way
- Documentation about how to run the tests

![image](https://user-images.githubusercontent.com/9013072/47183566-626e8c80-d2f6-11e8-87ba-5e691519a175.png)
(you can see that the timestamp is exactly the same for the two images)

## PR Checklist

- [ ] Documentation
- [x] Tests
